### PR TITLE
accept spaces as well as tabs in line parser regex

### DIFF
--- a/db.go
+++ b/db.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-const ouiReStr = `^(\S+)\t+(\S+)(\s+#\s+(\S.*))?`
+const ouiReStr = `^(\S+)\s*\t+(\S+)(\s+#\s+(\S.*))?`
 
 var ErrInvalidMACAddress = errors.New("invalid MAC address")
 


### PR DESCRIPTION
The current manuf file generated by wireshark are space padded and tab separated.

https://www.wireshark.org/download/automated/data/manuf

